### PR TITLE
Added argument to skip ad segments

### DIFF
--- a/RecordingThread.py
+++ b/RecordingThread.py
@@ -27,5 +27,5 @@ class RecordingThread(threading.Thread):
     @staticmethod
     def start_recording(streamer_name: str, full_path: str):
         params = ["streamlink", "-o", full_path, f"https://www.twitch.tv/{streamer_name}", "best",
-                  "--twitch-disable-hosting"]
+                  "--twitch-disable-hosting", "--twitch-disable-ads"]
         return subprocess.Popen(params)


### PR DESCRIPTION
Added the --twitch-disable-ads argument to skip embedded advertisement segments at the beginning or during a stream.